### PR TITLE
Add unit output option in default project

### DIFF
--- a/fptestlazideintf.pas
+++ b/fptestlazideintf.pas
@@ -177,6 +177,8 @@ begin
   // compiler options
   AProject.LazCompilerOptions.UseLineInfoUnit:=true;
   AProject.LazCompilerOptions.Win32GraphicApp:=true;
+  AProject.LazCompilerOptions.TargetFilename:='fptestproject1';
+  AProject.LazCompilerOptions.UnitOutputDirectory:='lib'+PathDelim+'$(TargetCPU)-$(TargetOS)';
   Result:=mrOK;
 end;
 
@@ -370,6 +372,9 @@ begin
 
   // compiler options
   AProject.LazCompilerOptions.UseLineInfoUnit:=true;
+  AProject.LazCompilerOptions.Win32GraphicApp:=False;
+  AProject.LazCompilerOptions.TargetFilename:='fptestproject1';
+  AProject.LazCompilerOptions.UnitOutputDirectory:='lib'+PathDelim+'$(TargetCPU)-$(TargetOS)';
   Result:=mrOK;
 end;
 


### PR DESCRIPTION
In the created projects the output path will be set to /lib