### PR TITLE
Replace WideString by UnicodeString and TObjectList by TFPObjectList

### DIFF
--- a/src/TestFramework.pas
+++ b/src/TestFramework.pas
@@ -240,18 +240,18 @@ type
     function  GetMemDiffStr(const expected, actual: pointer;
                             const size: longword; const ErrorMsg: string): string;
 
-    function  EqualsErrorMessage(const expected, actual :WideString;
-                                 const ErrorMsg: string): WideString; virtual;
-    function  NotEqualsErrorMessage(const expected, actual :WideString;
-                                    const ErrorMsg: string): WideString; virtual;
+    function  EqualsErrorMessage(const expected, actual :UnicodeString;
+                                 const ErrorMsg: string): UnicodeString; virtual;
+    function  NotEqualsErrorMessage(const expected, actual :UnicodeString;
+                                    const ErrorMsg: string): UnicodeString; virtual;
   public
     procedure Fail(const ErrorMsg: string;
                    const ErrorAddress: Pointer = nil);
-    procedure FailEquals(const expected, actual: WideString;
+    procedure FailEquals(const expected, actual: UnicodeString;
                          const ErrorMsg: string = ''; ErrorAddrs: Pointer = nil); //virtual;
-    procedure FailNotEquals(const expected, actual: WideString;
+    procedure FailNotEquals(const expected, actual: UnicodeString;
                             const ErrorMsg: string = ''; ErrorAddrs: Pointer = nil); //virtual;
-    procedure FailNotSame(const expected, actual: WideString;
+    procedure FailNotSame(const expected, actual: UnicodeString;
                           const ErrorMsg: string = ''; ErrorAddrs: Pointer = nil); //virtual;
     procedure OnCheckCalled;
 
@@ -282,9 +282,9 @@ type
     procedure CheckNotEqualsString(const expected, actual: string;
                                    const ErrorMsg: string = '');
   {$IFNDEF UNICODE}
-    procedure CheckEquals(const expected, actual: WideString;
+    procedure CheckEquals(const expected, actual: UnicodeString;
                           const ErrorMsg: string= ''); overload;
-    procedure CheckNotEquals(const expected, actual: WideString;
+    procedure CheckNotEquals(const expected, actual: UnicodeString;
                              const ErrorMsg: string = ''); overload;
     procedure CheckEqualsMem(const expected, actual: pointer;
                              const size:longword;
@@ -293,9 +293,9 @@ type
                                 const size:longword;
                                 const ErrorMsg:string='');
   {$ENDIF}
-    procedure CheckEqualsWideString(const expected, actual: WideString;
+    procedure CheckEqualsUnicodeString(const expected, actual: UnicodeString;
                                     const ErrorMsg: string= '');
-    procedure CheckNotEqualsWideString(const expected, actual: WideString;
+    procedure CheckNotEqualsUnicodeString(const expected, actual: UnicodeString;
                                        const ErrorMsg: string = '');
     procedure CheckEqualsBin(const expected, actual: longword;
                              const ErrorMsg: string = '';
@@ -2951,8 +2951,8 @@ begin
 end;
 
 {---------- helper functions ------------}
-function TTestProc.EqualsErrorMessage(const expected, actual: WideString;
-                                      const ErrorMsg: string): WideString;
+function TTestProc.EqualsErrorMessage(const expected, actual: UnicodeString;
+                                      const ErrorMsg: string): UnicodeString;
 begin
   if (ErrorMsg <> '') then
     Result := Format(sMsgActualEqualsExpFmt, [ErrorMsg + ', ', expected, actual])
@@ -2960,8 +2960,8 @@ begin
     Result := Format(sActualEqualsExpFmt, [expected, actual])
 end;
 
-function TTestProc.NotEqualsErrorMessage(const expected, actual: WideString;
-                                         const ErrorMsg: string): WideString;
+function TTestProc.NotEqualsErrorMessage(const expected, actual: UnicodeString;
+                                         const ErrorMsg: string): UnicodeString;
 begin
   if (ErrorMsg <> '') then
     Result := Format(sExpectedButWasAndMessageFmt, [ErrorMsg, expected, actual])
@@ -2987,21 +2987,21 @@ begin
     raise EPostTestFailure.Create(ErrorMsg) at ErrorAddress;
 end;
 
-procedure TTestProc.FailEquals(const expected, actual: WideString;
+procedure TTestProc.FailEquals(const expected, actual: UnicodeString;
                                const ErrorMsg: string;
                                      ErrorAddrs: Pointer);
 begin
   Fail(EqualsErrorMessage(expected, actual, ErrorMsg), ErrorAddrs);
 end;
 
-procedure TTestProc.FailNotEquals(const expected, actual: WideString;
+procedure TTestProc.FailNotEquals(const expected, actual: UnicodeString;
                                   const ErrorMsg: string;
                                         ErrorAddrs: Pointer);
 begin
   Fail(NotEqualsErrorMessage(expected, actual, ErrorMsg), ErrorAddrs);
 end;
 
-procedure TTestProc.FailNotSame(const expected, actual: WideString;
+procedure TTestProc.FailNotSame(const expected, actual: UnicodeString;
                                 const ErrorMsg: string;
                                       ErrorAddrs: Pointer);
 begin
@@ -3102,7 +3102,7 @@ begin
 end;
 
 {$IFNDEF UNICODE}
-procedure TTestProc.CheckEquals(const expected, actual: WideString;
+procedure TTestProc.CheckEquals(const expected, actual: UnicodeString;
     const ErrorMsg: string);
 begin
   OnCheckCalled;
@@ -3118,7 +3118,7 @@ begin
     Fail(GetMemDiffStr(expected, actual, size, ErrorMsg), CallerAddr);
 end;
 
-procedure TTestProc.CheckNotEquals(const expected, actual: WideString;
+procedure TTestProc.CheckNotEquals(const expected, actual: UnicodeString;
     const ErrorMsg: string);
 begin
   OnCheckCalled;
@@ -3140,7 +3140,7 @@ begin
 end;
 {$ENDIF}
 
-procedure TTestProc.CheckEqualsWideString(const expected, actual: WideString;
+procedure TTestProc.CheckEqualsUnicodeString(const expected, actual: UnicodeString;
     const ErrorMsg: string);
 begin
   OnCheckCalled;
@@ -3148,7 +3148,7 @@ begin
     FailNotEquals(expected, actual, ErrorMsg, CallerAddr);
 end;
 
-procedure TTestProc.CheckNotEqualsWideString(const expected, actual: WideString;
+procedure TTestProc.CheckNotEqualsUnicodeString(const expected, actual: UnicodeString;
     const ErrorMsg: string);
 begin
   OnCheckCalled;

--- a/src/TestFrameworkIfaces.pas
+++ b/src/TestFrameworkIfaces.pas
@@ -316,11 +316,11 @@ type
                    const ErrorAddress: Pointer = nil);
     procedure Fail(const ErrorMsg: string;
                    const ErrorAddress: Pointer = nil);
-    procedure FailEquals(const expected, actual: WideString;
+    procedure FailEquals(const expected, actual: UnicodeString;
                          const ErrorMsg: string = ''; ErrorAddrs: Pointer = nil);
-    procedure FailNotEquals(const expected, actual: WideString;
+    procedure FailNotEquals(const expected, actual: UnicodeString;
                             const ErrorMsg: string = ''; ErrorAddrs: Pointer = nil);
-    procedure FailNotSame(const expected, actual: WideString;
+    procedure FailNotSame(const expected, actual: UnicodeString;
                           const ErrorMsg: string = ''; ErrorAddrs: Pointer = nil);
     //function  get_ExceptionClass: ExceptClass;
     //procedure set_ExceptionClass(const Value: ExceptClass);
@@ -359,9 +359,9 @@ type
     procedure CheckNotEqualsString(const expected, actual: string;
                                    const ErrorMsg: string = '');
   {$IFNDEF UNICODE}
-    procedure CheckEquals(const expected, actual: WideString;
+    procedure CheckEquals(const expected, actual: UnicodeString;
                           const ErrorMsg: string= ''); overload;
-    procedure CheckNotEquals(const expected, actual: WideString;
+    procedure CheckNotEquals(const expected, actual: UnicodeString;
                              const ErrorMsg: string = ''); overload;
     procedure CheckEqualsMem(const expected, actual: pointer;
                              const size:longword;
@@ -370,9 +370,9 @@ type
                                 const size:longword;
                                 const ErrorMsg:string='');
   {$ENDIF}
-    procedure CheckEqualsWideString(const expected, actual: WideString;
+    procedure CheckEqualsUnicodeString(const expected, actual: UnicodeString;
                                     const ErrorMsg: string= '');
-    procedure CheckNotEqualsWideString(const expected, actual: WideString;
+    procedure CheckNotEqualsUnicodeString(const expected, actual: UnicodeString;
                                        const ErrorMsg: string = '');
     procedure CheckEqualsBin(const expected, actual: longword;
                              const ErrorMsg: string = '';

--- a/src/XMLListener.pas
+++ b/src/XMLListener.pas
@@ -138,7 +138,7 @@ const
 type
   TXMLStack = class(TInterfacedObject, IXMLStack)
   private
-    FStack: TObjectList;
+    FStack: TFPObjectList;
   protected
     function  Pop: TDomElement;
     procedure Push(const ANode: TDomElement);
@@ -152,7 +152,7 @@ type
 constructor TXMLStack.Create;
 begin
   inherited Create;
-  FStack := TObjectList.Create(False);
+  FStack := TFPObjectList.Create(False);
 end;
 
 destructor TXMLStack.Destroy;


### PR DESCRIPTION
WideString and UnicodeString are similar, the only difference is the memory management at windows, the later being faster
TFPObjectList is lighter than TObjectList