### PR TITLE
Add support for Pointers in CheckNull() and CheckNotNull()

### DIFF
--- a/src/TestFramework.pas
+++ b/src/TestFramework.pas
@@ -317,6 +317,10 @@ type
                            const ErrorMsg: string = ''); overload;
     procedure CheckNull(const obj: TObject;
                         const ErrorMsg: string = ''); overload;
+    procedure CheckNotNull(const obj :Pointer;
+                           const ErrorMsg :string = ''); overload;
+    procedure CheckNull(const obj: Pointer;
+                        const ErrorMsg: string = ''); overload;
     procedure CheckNotSame(const expected, actual: IInterface;
                            const ErrorMsg: string = ''); overload;
     procedure CheckSame(const expected, actual: TObject;
@@ -3309,6 +3313,20 @@ begin
   OnCheckCalled;
   if obj <> nil then
     FailEquals('nil', PtrToStr(Pointer(obj)), ErrorMsg, CallerAddr);
+end;
+
+procedure TTestProc.CheckNotNull(const obj: Pointer; const ErrorMsg: string);
+begin
+  OnCheckCalled;
+  if obj = nil then
+    FailNotEquals('pointer', PtrToStr(obj), ErrorMsg, CallerAddr);
+end;
+
+procedure TTestProc.CheckNull(const obj: Pointer; const ErrorMsg: string);
+begin
+  OnCheckCalled;
+  if obj <> nil then
+    FailEquals('nil', PtrToStr(obj), ErrorMsg, CallerAddr);
 end;
 
 procedure TTestProc.CheckException(const AMethod: TExceptTestMethod;

--- a/src/TestFrameworkIfaces.pas
+++ b/src/TestFrameworkIfaces.pas
@@ -395,6 +395,10 @@ type
                            const ErrorMsg: string = ''); overload;
     procedure CheckNull(const obj: TObject;
                         const ErrorMsg: string = ''); overload;
+    procedure CheckNotNull(const obj :Pointer;
+                           const ErrorMsg :string = ''); overload;
+    procedure CheckNull(const obj: Pointer;
+                        const ErrorMsg: string = ''); overload;
     procedure CheckNotSame(const expected, actual: IInterface;
                            const ErrorMsg: string = ''); overload;
     procedure CheckSame(const expected, actual: TObject;


### PR DESCRIPTION
**What this PR does:**
This PR adds two overloaded methods and implements them. 

- CheckNull()
- CheckNotNull()

They allow for **checking simple pointers (type Pointer) against nil**. Before these methods only accepted IInterface and TObject pointers as arguments.

**Implemention idea**

1. On implementing I thought about using _ptr_ instead of _obj_ as handle for simple pointers. For consistence I decided to use _obj_.
2. There are further methods which should be enabled to handle pointers (which now exclusively handle IInterface and TObject). I could add them to this PR if desired. They could also be added separately. 

Best regards
Matthias
